### PR TITLE
Support relative path for --conf-dir

### DIFF
--- a/ansible_deployer/command_line.py
+++ b/ansible_deployer/command_line.py
@@ -100,7 +100,10 @@ def parse_options(argv):
     options["debug"] = arguments.debug
     options["syslog"] = arguments.syslog
     options["limit"] = arguments.limit[0]
-    options["conf_dir"] = arguments.conf_dir[0]
+    if arguments.conf_dir[0]:
+        options["conf_dir"] = os.path.abspath(arguments.conf_dir[0])
+    else:
+        options["conf_dir"] = None
 
 
     arguments = parser.parse_args(argv)


### PR DESCRIPTION
Since we're changing CWD inside ansible-deployer we need to translate
the relative path to absolute parsing options