### PR TITLE
Remove redundant setLevel for console_handler in logging

### DIFF
--- a/source/modules/outputs/logging.py
+++ b/source/modules/outputs/logging.py
@@ -27,7 +27,6 @@ class Loggers:
 
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(console_formatter)
-        console_handler.setLevel(logging.INFO)
         console_handler.setLevel(logging.DEBUG if options["debug"] else logging.INFO)
         logger.addHandler(console_handler)
 


### PR DESCRIPTION
Bugfix commit a2c68e160ccfd09c12f7f4dba8b59c3e2595a321

fixing issue #128 